### PR TITLE
Update tests

### DIFF
--- a/test/integrationTests/completionProvider.integration.test.ts
+++ b/test/integrationTests/completionProvider.integration.test.ts
@@ -42,30 +42,39 @@ suite(`${OmniSharpCompletionProvider.name}: Returns the completion items`, () =>
         expect(completionList.items).to.not.be.empty;
     });
 
-    test("Preselect is enabled for at least one completionItem when there is a new", async () => {
-        let completionList = <vscode.CompletionList>(await vscode.commands.executeCommand("vscode.executeCompletionItemProvider", fileUri, new vscode.Position(8, 31), " "));
-        let preselectList = completionList.items.filter(item => item.preselect === true);
-        expect(preselectList).to.not.be.empty;
-    });
-
     test("Resolve adds documentation", async () => {
-        let completionList = <vscode.CompletionList>(await vscode.commands.executeCommand("vscode.executeCompletionItemProvider", fileUri, new vscode.Position(8, 31), " ", 10));
+        let completionList = <vscode.CompletionList>(await vscode.commands.executeCommand("vscode.executeCompletionItemProvider", fileUri, new vscode.Position(8, 31), /*trigger character*/ undefined, /* completions to resolve */ 10));
         // At least some of the first 10 fully-resolved elements should have documentation attached. If this ever ends up not being
         // true, adjust the cutoff appropriately.
         const documentation = completionList.items.slice(0, 9).filter(item => item.documentation);
         expect(documentation).to.not.be.empty;
     });
 
-    test("Override completion has additional edits", async () => {
-        let completionList = <vscode.CompletionList>(await vscode.commands.executeCommand("vscode.executeCompletionItemProvider", fileUri, new vscode.Position(11, 17), " "));
+    test("Override completion has additional edits sync", async () => {
+        let completionList = <vscode.CompletionList>(await vscode.commands.executeCommand("vscode.executeCompletionItemProvider", fileUri, new vscode.Position(11, 17), " ", 4));
         const nonSnippets = completionList.items.filter(c => c.kind != vscode.CompletionItemKind.Snippet);
+
+        let sawAdditionalTextEdits = false;
+        let sawEmptyAdditionalTextEdits = false;
+
         for (const i of nonSnippets) {
             expect((<vscode.SnippetString>i.insertText).value).contains("$0");
-            expect(i.additionalTextEdits).is.not.null;
-            expect(i.additionalTextEdits[0].range.start.line).equals(11);
-            expect(i.additionalTextEdits[0].range.start.character).equals(8);
-            expect(i.additionalTextEdits[0].range.end.line).equals(11);
-            expect(i.additionalTextEdits[0].range.end.character).equals(16);
+            if (i.additionalTextEdits) {
+                sawAdditionalTextEdits = true;
+                expect(i.additionalTextEdits).to.be.array();
+                expect(i.additionalTextEdits.length).to.equal(1);
+                expect(i.additionalTextEdits[0].newText).to.equal("using singleCsproj2;\n");
+                expect(i.additionalTextEdits[0].range.start.line).to.equal(1);
+                expect(i.additionalTextEdits[0].range.start.character).to.equal(0);
+                expect(i.additionalTextEdits[0].range.end.line).to.equal(1);
+                expect(i.additionalTextEdits[0].range.end.character).to.equal(1);
+            }
+            else {
+                sawEmptyAdditionalTextEdits = true;
+            }
         }
+
+        expect(sawAdditionalTextEdits).to.be.true;
+        expect(sawEmptyAdditionalTextEdits).to.be.true;
     });
 });

--- a/test/integrationTests/testAssets/singleCsproj/completion.cs
+++ b/test/integrationTests/testAssets/singleCsproj/completion.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace singleCsproj
 {
-    class Completion
+    class Completion : CompletionBase
     {
         static void shouldHaveCompletions(string[] args)
         {

--- a/test/integrationTests/testAssets/singleCsproj/completionBase.cs
+++ b/test/integrationTests/testAssets/singleCsproj/completionBase.cs
@@ -1,0 +1,14 @@
+using singleCsproj2;
+
+namespace singleCsproj
+{
+    class CompletionBase
+    {
+        public virtual void Method(NeedsImport n) {}
+    }
+}
+
+namespace singleCsproj2
+{
+    class NeedsImport {}
+}

--- a/test/integrationTests/testAssets/slnFilterWithCsproj/src/app/completion.cs
+++ b/test/integrationTests/testAssets/slnFilterWithCsproj/src/app/completion.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace singleCsproj
 {
-    class Completion
+    class Completion : CompletionBase
     {
         static void shouldHaveCompletions(string[] args)
         {

--- a/test/integrationTests/testAssets/slnFilterWithCsproj/src/app/completionBase.cs
+++ b/test/integrationTests/testAssets/slnFilterWithCsproj/src/app/completionBase.cs
@@ -1,0 +1,14 @@
+using singleCsproj2;
+
+namespace singleCsproj
+{
+    class CompletionBase
+    {
+        public virtual void Method(NeedsImport n) {}
+    }
+}
+
+namespace singleCsproj2
+{
+    class NeedsImport {}
+}

--- a/test/integrationTests/testAssets/slnWithCsproj/src/app/completion.cs
+++ b/test/integrationTests/testAssets/slnWithCsproj/src/app/completion.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace singleCsproj
 {
-    class Completion
+    class Completion : CompletionBase
     {
         static void shouldHaveCompletions(string[] args)
         {

--- a/test/integrationTests/testAssets/slnWithCsproj/src/app/completionBase.cs
+++ b/test/integrationTests/testAssets/slnWithCsproj/src/app/completionBase.cs
@@ -1,0 +1,14 @@
+using singleCsproj2;
+
+namespace singleCsproj
+{
+    class CompletionBase
+    {
+        public virtual void Method(NeedsImport n) {}
+    }
+}
+
+namespace singleCsproj2
+{
+    class NeedsImport {}
+}


### PR DESCRIPTION
* Preselect is no longer true for most scenarios, matching VS behavior.
* Typing space after a `new` no longer pops completion, matching VS behavior.
* Synchronous override completion only returns additional text edits for added usings. Test baseline updated.